### PR TITLE
Add CORS configuration to WebSecurityConfig for allowed origins and m…

### DIFF
--- a/src/main/java/uwu/connectra/connectra_backend/config/WebSecurityConfig.java
+++ b/src/main/java/uwu/connectra/connectra_backend/config/WebSecurityConfig.java
@@ -17,6 +17,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -37,6 +41,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(urlBasedCorsConfigurationSource()))
                 .sessionManagement(
                         session -> session
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -74,5 +79,28 @@ public class WebSecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
             throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource(){
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(
+                        "http://localhost:3000",
+                        "http://localhost:3001"
+                )
+        );
+        configuration.setAllowedMethods(List.of(
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "OPTIONS"
+        ));
+        configuration.addAllowedHeader("*");
+        configuration.addExposedHeader("Authorization");
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
This pull request updates the `WebSecurityConfig` in the backend to properly configure CORS (Cross-Origin Resource Sharing) for development environments. The main focus is to allow frontend applications running on `localhost:3000` and `localhost:3001` to interact securely with the backend API.

**CORS Configuration Enhancements:**

* Added a new bean method `urlBasedCorsConfigurationSource` to define allowed origins, HTTP methods, headers, and credentials for CORS requests. This ensures that requests from local frontend development servers are permitted and properly handled.
* Updated the security filter chain to use the custom CORS configuration source, integrating CORS handling into the Spring Security setup.
* Imported necessary classes for CORS configuration, including `CorsConfiguration` and `UrlBasedCorsConfigurationSource`.…ethods